### PR TITLE
Retry in the event of 'unretryable' exceptions

### DIFF
--- a/iotcore/src/main/java/com/google/android/things/iotcore/IotClientLogger.java
+++ b/iotcore/src/main/java/com/google/android/things/iotcore/IotClientLogger.java
@@ -19,7 +19,7 @@ public interface IotClientLogger {
     /** Background thread is shutting down */
     void onThreadShutdown();
 
-    /** Error signing JWT */
+    /** Error signing JWT. Client will shut down and not attempt to reconnect. */
     void onJwtException(JoseException e);
 
     /** Error publishing message */
@@ -31,9 +31,12 @@ public interface IotClientLogger {
     /** Disconnected (may be called multiple times for a single disconnection event) */
     void onDisconnect(@DisconnectReason final int disconnectReason);
 
-    /** Hit a "retryable" exception (meaning the client will attempt to reconnect */
+    /** Hit a "retryable" exception (meaning the client will attempt to reconnect) */
     void onRetryableException(MqttException e);
 
-    /** Hit an "unretryable" exception (meaning the client will shut down and not attempt to reconnect */
+    /**
+     * Hit an "unretryable" exception according to Google's IoT SDK classification (but the client
+     * will actually still backoff and retry to avoid getting stuck offline)
+     */
     void onUnretryableException(MqttException e);
 }


### PR DESCRIPTION
Based on the data (https://chartio.com/skip-scooters/dashboard/426088/link_sharing/1a69c9be0f8b12140d4f90721f2b80a3360e3433a8501bc127e2743db7976d3d/) it seems like the "unretryable" exceptions we've seen are actually transient issues, so this change should prevent devices from dropping offline if they hit a transient "unretryable" exception.

There were 2 approaches I considered:
- Change the definition of "retryable" exceptions to explicitly include all exception types we've seen so far (SocketTimeoutException, NoRouteToHostException, etc) and leave the unretryable behavior unchanged (shut down the client)
- Leave the definition of "retryable" unchanged, but don't make unretryable exceptions shut down the client

I went with the 2nd approach since it means we'll still log the errors (so we can validate that retrying is actually useful). We can always revisit if there is too much getting logged that's not useful (currently the max backoff between retries is 64 seconds).